### PR TITLE
Fix the ARCH type in build_vsm_optee script

### DIFF
--- a/scripts/build_vsm_optee.sh
+++ b/scripts/build_vsm_optee.sh
@@ -6,7 +6,7 @@
 
 export TOP_DIR=$1
 export INSTALL_DEPENDENCY=$2
-export ARCH=x64
+export ARCH=x86
 export CC=x86_64-linux-gnu-gcc
 export CXX=x86_64-linux-gnu-gcc-g++
 export TA_DEV_KIT_ROOT=$TOP_DIR/


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
While building the VSM kmodule, the Makefile searched for a directory called x64 since the ARCH variable was set to x64 in the build script. Hence the VSM kmodule could not be built.
This PR sets the ARCH env variable to x86 in the build script and fixes the above error.